### PR TITLE
Fix FTBFS on deepin snipe: Python 3.12 distutils + dwz DWARF 5

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -4,6 +4,9 @@ libplist (2.2.0-6deepin1) unstable; urgency=medium
     Python-3.12.patch: replace distutils with stdlib sysconfig module in
     m4/ax_python_devel.m4, fixing FTBFS with Python 3.12 where distutils
     was removed (PEP 632).
+  * debian/rules: force -gdwarf-4 via DEB_CFLAGS_MAINT_APPEND and
+    DEB_CXXFLAGS_MAINT_APPEND; the build chroot's dwz 0.14 cannot process
+    DWARF 5 .debug_addr sections emitted by GCC 12's default.
 
  -- jiabowen <jiabowen@uniontech.com>  Mon, 06 Jul 2026 16:45:59 +0800
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+libplist (2.2.0-6deepin1) unstable; urgency=medium
+
+  * Add debian/patches/0001-m4-replace-distutils-with-sysconfig-for-
+    Python-3.12.patch: replace distutils with stdlib sysconfig module in
+    m4/ax_python_devel.m4, fixing FTBFS with Python 3.12 where distutils
+    was removed (PEP 632).
+
+ -- jiabowen <jiabowen@uniontech.com>  Mon, 06 Jul 2026 16:45:59 +0800
+
 libplist (2.2.0-6) unstable; urgency=medium
 
   [ Dylan Aïssi ]

--- a/debian/patches/0001-m4-replace-distutils-with-sysconfig-for-Python-3.12.patch
+++ b/debian/patches/0001-m4-replace-distutils-with-sysconfig-for-Python-3.12.patch
@@ -1,0 +1,129 @@
+Description: Replace distutils with sysconfig for Python 3.12 compatibility
+ distutils was removed in Python 3.12 (PEP 632). The AX_PYTHON_DEVEL macro
+ from autoconf-archive uses distutils.sysconfig extensively to discover
+ Python include paths, library paths, and config variables. Replace all
+ distutils.sysconfig usage with the stdlib sysconfig module, which provides
+ equivalent functionality and is not deprecated.
+ .
+ This fixes the build failure:
+   configure: error: cannot import Python module "distutils".
+Author: jiabowen <jiabowen@uniontech.com>
+
+--- a/m4/ax_python_devel.m4
++++ b/m4/ax_python_devel.m4
+@@ -133,17 +133,17 @@
+ 	fi
+ 
+ 	#
+-	# Check if you have distutils, else fail
++	# Check if you have sysconfig, else fail
+ 	#
+-	AC_MSG_CHECKING([for the distutils Python package])
+-	ac_distutils_result=`$PYTHON -c "import distutils" 2>&1`
++	AC_MSG_CHECKING([for the sysconfig Python module])
++	ac_sysconfig_result=`$PYTHON -c "import sysconfig" 2>&1`
+ 	if test $? -eq 0; then
+ 		AC_MSG_RESULT([yes])
+ 	else
+ 		AC_MSG_RESULT([no])
+-		AC_MSG_ERROR([cannot import Python module "distutils".
++		AC_MSG_ERROR([cannot import Python module "sysconfig".
+ Please check your Python installation. The error was:
+-$ac_distutils_result])
++$ac_sysconfig_result])
+ 		PYTHON_VERSION=""
+ 	fi
+ 
+@@ -152,10 +152,10 @@
+ 	#
+ 	AC_MSG_CHECKING([for Python include path])
+ 	if test -z "$PYTHON_CPPFLAGS"; then
+-		python_path=`$PYTHON -c "import distutils.sysconfig; \
+-			print (distutils.sysconfig.get_python_inc ());"`
+-		plat_python_path=`$PYTHON -c "import distutils.sysconfig; \
+-			print (distutils.sysconfig.get_python_inc (plat_specific=1));"`
++		python_path=`$PYTHON -c "import sysconfig; \
++			print (sysconfig.get_path ('include'));"`
++		plat_python_path=`$PYTHON -c "import sysconfig; \
++			print (sysconfig.get_path ('platinclude'));"`
+ 		if test -n "${python_path}"; then
+ 			if test "${plat_python_path}" != "${python_path}"; then
+ 				python_path="-I$python_path -I$plat_python_path"
+@@ -179,8 +179,8 @@
+ 
+ # join all versioning strings, on some systems
+ # major/minor numbers could be in different list elements
+-from distutils.sysconfig import *
+-e = get_config_var('VERSION')
++import sysconfig
++e = sysconfig.get_config_var('VERSION')
+ if e is not None:
+ 	print(e)
+ EOD`
+@@ -202,8 +202,8 @@
+ 		ac_python_libdir=`cat<<EOD | $PYTHON -
+ 
+ # There should be only one
+-import distutils.sysconfig
+-e = distutils.sysconfig.get_config_var('LIBDIR')
++import sysconfig
++e = sysconfig.get_config_var('LIBDIR')
+ if e is not None:
+ 	print (e)
+ EOD`
+@@ -211,8 +211,8 @@
+ 		# Now, for the library:
+ 		ac_python_library=`cat<<EOD | $PYTHON -
+ 
+-import distutils.sysconfig
+-c = distutils.sysconfig.get_config_vars()
++import sysconfig
++c = sysconfig.get_config_vars()
+ if 'LDVERSION' in c:
+ 	print ('python'+c[['LDVERSION']])
+ else:
+@@ -231,9 +231,8 @@
+ 		else
+ 			# old way: use libpython from python_configdir
+ 			ac_python_libdir=`$PYTHON -c \
+-			  "from distutils.sysconfig import get_python_lib as f; \
+-			  import os; \
+-			  print (os.path.join(f(plat_specific=1, standard_lib=1), 'config'));"`
++			  "import sysconfig, os; \
++			  print (os.path.join(sysconfig.get_path('platstdlib'), 'config'));"`
+ 			PYTHON_LIBS="-L$ac_python_libdir -lpython$ac_python_version"
+ 		fi
+ 
+@@ -252,8 +251,8 @@
+ 	#
+ 	AC_MSG_CHECKING([for Python site-packages path])
+ 	if test -z "$PYTHON_SITE_PKG"; then
+-		PYTHON_SITE_PKG=`$PYTHON -c "import distutils.sysconfig; \
+-			print (distutils.sysconfig.get_python_lib(0,0));"`
++		PYTHON_SITE_PKG=`$PYTHON -c "import sysconfig; \
++			print (sysconfig.get_path('purelib'));"`
+ 	fi
+ 	AC_MSG_RESULT([$PYTHON_SITE_PKG])
+ 	AC_SUBST([PYTHON_SITE_PKG])
+@@ -263,8 +262,8 @@
+ 	#
+ 	AC_MSG_CHECKING(python extra libraries)
+ 	if test -z "$PYTHON_EXTRA_LIBS"; then
+-	   PYTHON_EXTRA_LIBS=`$PYTHON -c "import distutils.sysconfig; \
+-                conf = distutils.sysconfig.get_config_var; \
++	   PYTHON_EXTRA_LIBS=`$PYTHON -c "import sysconfig; \
++                conf = sysconfig.get_config_var; \
+                 print (conf('LIBS') + ' ' + conf('SYSLIBS'))"`
+ 	fi
+ 	AC_MSG_RESULT([$PYTHON_EXTRA_LIBS])
+@@ -275,8 +274,8 @@
+ 	#
+ 	AC_MSG_CHECKING(python extra linking flags)
+ 	if test -z "$PYTHON_EXTRA_LDFLAGS"; then
+-		PYTHON_EXTRA_LDFLAGS=`$PYTHON -c "import distutils.sysconfig; \
+-			conf = distutils.sysconfig.get_config_var; \
++		PYTHON_EXTRA_LDFLAGS=`$PYTHON -c "import sysconfig; \
++			conf = sysconfig.get_config_var; \
+ 			print (conf('LINKFORSHARED'))"`
+ 	fi
+ 	AC_MSG_RESULT([$PYTHON_EXTRA_LDFLAGS])

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,0 +1,1 @@
+0001-m4-replace-distutils-with-sysconfig-for-Python-3.12.patch

--- a/debian/rules
+++ b/debian/rules
@@ -5,6 +5,10 @@
 
 # see FEATURE AREAS in dpkg-buildflags(1)
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all
+# Force DWARF 4: the build chroot ships dwz 0.14 which cannot process
+# DWARF 5 .debug_addr sections emitted by GCC 12's default -gdwarf-5.
+export DEB_CFLAGS_MAINT_APPEND = -gdwarf-4
+export DEB_CXXFLAGS_MAINT_APPEND = -gdwarf-4
 export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed -Wl,-O1 -Wl,-z,defs
 export QT_SELECT := 5
 


### PR DESCRIPTION
## Problems

`libplist` fails to build from source on the deepin snipe-2500u1 build environment (Python 3.12, GCC 12, dwz 0.14). Two independent FTBFS:

### 1. configure fails — `distutils` removed in Python 3.12

```
checking for the distutils Python package... no
configure: error: cannot import Python module "distutils".
ModuleNotFoundError: No module named 'distutils'
```

Python 3.12 removed `distutils` ([PEP 632](https://peps.python.org/pep-0632/)). The vendored `AX_PYTHON_DEVEL` autoconf macro in `m4/ax_python_devel.m4` (autoconf-archive serial 21) uses `distutils.sysconfig` extensively to discover Python include/library paths and config vars.

### 2. dh_dwz fails — DWARF 5 unsupported by old dwz

```
dwz: ...libplist-2.0.so.3.3.0: Unknown debugging section .debug_addr
dh_dwz: error: dwz returned exit code 1
```

GCC 12 defaults to `-gdwarf-5`; the build chroot's `dwz 0.14` (2021) cannot process the DWARF 5 `.debug_addr` section.

## Fixes

### Fix 1: quilt patch — replace distutils with stdlib sysconfig

New quilt patch `debian/patches/0001-m4-replace-distutils-with-sysconfig-for-Python-3.12.patch` replaces all `distutils.sysconfig` usage with the stdlib `sysconfig` module (not deprecated):

| distutils API | sysconfig replacement |
|---|---|
| `import distutils` | `import sysconfig` |
| `distutils.sysconfig.get_python_inc()` | `sysconfig.get_path('include')` |
| `distutils.sysconfig.get_python_inc(plat_specific=1)` | `sysconfig.get_path('platinclude')` |
| `distutils.sysconfig.get_python_lib(0,0)` | `sysconfig.get_path('purelib')` |
| `distutils.sysconfig.get_python_lib(plat_specific=1, standard_lib=1)` | `sysconfig.get_path('platstdlib')` |
| `distutils.sysconfig.get_config_var(...)` | `sysconfig.get_config_var(...)` |
| `distutils.sysconfig.get_config_vars()` | `sysconfig.get_config_vars()` |

### Fix 2: debian/rules — force DWARF 4

```makefile
export DEB_CFLAGS_MAINT_APPEND = -gdwarf-4
export DEB_CXXFLAGS_MAINT_APPEND = -gdwarf-4
```

Forces GCC to emit DWARF 4 (no `.debug_addr`), which `dwz 0.14` processes correctly.

## Verification

All `sysconfig` equivalents verified to return correct values on Python 3.12. Patch applies cleanly (`patch -p1`, 9 hunks, 0 rejects). **Full build verified passing.** No `debian/control` changes needed — `sysconfig` is a built-in Python stdlib module.

## Changelog

Bumped to `2.2.0-6deepin1`.